### PR TITLE
Don't convert & into &amp

### DIFF
--- a/formtools_addons/__init__.py
+++ b/formtools_addons/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.35'
+__version__ = '0.1.36'
 
 from .wizard.views.multipleformwizard import (
     SessionMultipleFormWizardView, CookieMultipleFormWizardView,

--- a/formtools_addons/static/formtools_addons/js/wizardapi.js
+++ b/formtools_addons/static/formtools_addons/js/wizardapi.js
@@ -135,7 +135,7 @@
         var text = document.createTextNode(html);
         var div = document.createElement('div');
         div.appendChild(text);
-        return div.innerHTML;
+        return div.textContent;
     };
 
     $.fn.serializeObject = function(){

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.35
+current_version = 0.1.36
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from pip.req import parse_requirements
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-__version__ = '0.1.35'
+__version__ = '0.1.36'
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 requirements = [str(ir.req) for ir in parse_requirements(os.path.join(BASE_DIR, 'requirements.txt'), session=False)]


### PR DESCRIPTION
When using innerHTML while escape html from from data it converts & into &amp. textContent is an alternative and don't cause the same issue.