### PR TITLE
Cache get_form_list to speed-up wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ docs/_build
 
 # Dev db
 dev.sqlite.db
+
+venv/*

--- a/formtools_addons/wizard/views/wizardapi.py
+++ b/formtools_addons/wizard/views/wizardapi.py
@@ -33,6 +33,7 @@ class WizardAPIView(NamedUrlWizardView):
     substep_separator = None
     json_encoder_class = None
     _json_encoder = None
+    cached_form_list = None
 
     @classmethod
     def get_initkwargs(cls, form_list=None, initial_dict=None,
@@ -245,6 +246,12 @@ class WizardAPIView(NamedUrlWizardView):
 
         # Return current step_data, since the data was invalid
         return self.render_state(step=step, form=form, form_data=form_data, form_files=form_files, status_code=200)
+
+    def get_form_list(self):
+        # Overrides wizard method to speed-up
+        if not self.cached_form_list or not self.storage.data['step_data']:
+            self.cached_form_list = super(WizardAPIView, self).get_form_list()
+        return self.cached_form_list
 
     def get_failure_redirect_view(self, request, *args, **kwargs):
         return redirect('/')

--- a/formtools_addons/wizard/views/wizardapi.py
+++ b/formtools_addons/wizard/views/wizardapi.py
@@ -249,8 +249,9 @@ class WizardAPIView(NamedUrlWizardView):
 
     def get_form_list(self):
         # Overrides wizard method to speed-up
-        if not self.cached_form_list or not self.storage.data['step_data']:
+        if not self.cached_form_list:# or not self.storage.data['step_data']:
             self.cached_form_list = super(WizardAPIView, self).get_form_list()
+
         return self.cached_form_list
 
     def get_failure_redirect_view(self, request, *args, **kwargs):
@@ -344,6 +345,7 @@ class WizardAPIView(NamedUrlWizardView):
             return form.is_valid()
 
         valid = True
+        self.cached_form_list = None
         for form_key in self.get_form_list():
             form_obj = self.get_form(step=form_key,
                                      data=self.storage.get_step_data(form_key),


### PR DESCRIPTION
JIRA ticket: https://vikingco.atlassian.net/browse/VD-94

Due to being enable to have more than one form per page, here we cache
get_form_list method to reduce the amount of calls to lower levels
within the wizard.